### PR TITLE
Increase KeptnMetric Threshold

### DIFF
--- a/gitops/manifests/demo-application/keptn.yaml
+++ b/gitops/manifests/demo-application/keptn.yaml
@@ -42,4 +42,4 @@ spec:
     - keptnMetricRef:
         name: demoapp-latency
         namespace: demo
-      evaluationTarget: "<10" #less than 10s
+      evaluationTarget: "<20" #less than 20s


### PR DESCRIPTION
During first rollout on codespaces, the response time can fluctuate greatly.

I've seen figures of 12+ seconds. So increase this threshold to ensure first deployment doesn't fail.