### PR TITLE
Add retries and timeout

### DIFF
--- a/gitops/manifests/demo-application/keptn.yaml
+++ b/gitops/manifests/demo-application/keptn.yaml
@@ -4,6 +4,8 @@ metadata:
   name: load-test
   namespace: demo
 spec:
+  retries: 0
+  timeout: "5m"
   container:
     name: testy-test
     image: grafana/k6:0.45.0


### PR DESCRIPTION
This PR:

- Adds retry and timeout limits for the KeptnTask

If not present, `k6` will fail when deploying `V2` (the intentionally slow artifact) and thus keep resarting the job.

This configuration effectively says "try once and accept whatever the outcome is". In other words, if `k6` signals a failure and thus exits the job with a failure, accept the failure (as it is genuine) and move on.