### PR TITLE
chore: update collector image version

### DIFF
--- a/gitops/manifests/otel-collector/deploy.yaml
+++ b/gitops/manifests/otel-collector/deploy.yaml
@@ -103,7 +103,7 @@ spec:
           env:
             - name: GOGC
               value: "80"
-          image: otel/opentelemetry-collector:0.60.0
+          image: otel/opentelemetry-collector:0.85.0
           name: otel-collector
           resources:
             limits:


### PR DESCRIPTION
This PR:

- Updates the OTEL collector URL from `0.60.0` to `0.85.0`
- Closes #100 